### PR TITLE
feat: enforce maximum 2 rewards per milestone

### DIFF
--- a/models/StreakBonusConfig.js
+++ b/models/StreakBonusConfig.js
@@ -28,9 +28,10 @@ const milestoneSchema = new mongoose.Schema({
     required: true,
     validate: {
       validator: function(rewards) {
-        return Array.isArray(rewards) && rewards.length > 0;
+        // At least one reward is required, maximum 2 rewards allowed (coins and xp)
+        return Array.isArray(rewards) && rewards.length > 0 && rewards.length <= 2;
       },
-      message: 'At least one reward is required'
+      message: 'At least one reward is required, maximum 2 rewards allowed per milestone (Coins and XP)'
     }
   },
   claimMode: {

--- a/routes/admin-daily-challenges.js
+++ b/routes/admin-daily-challenges.js
@@ -1305,8 +1305,8 @@ router.put(
       .isBoolean()
       .withMessage("Active must be a boolean"),
     body("milestones.*.rewards")
-      .isArray({ min: 1 })
-      .withMessage("At least one reward is required"),
+      .isArray({ min: 1, max: 2 })
+      .withMessage("At least one reward is required, maximum 2 rewards allowed per milestone (Coins and XP)"),
     body("milestones.*.rewards.*.type")
       .isIn(["coins", "xp"])
       .withMessage("Reward type must be coins or xp"),


### PR DESCRIPTION
Limit milestone rewards to 2 (Coins and XP) across frontend and backend validation.