### PR TITLE
fix: normalize emails to lowercase in login and admin update routes

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1442,10 +1442,12 @@ router.put(
         });
       }
 
-      // Check email uniqueness if being updated
-      if (updateData.email && updateData.email !== existingUser.email) {
+      // Check email uniqueness if being updated (compare case-insensitively)
+      const normalizedNewEmail = updateData.email ? updateData.email.toLowerCase() : null;
+      const normalizedExistingEmail = existingUser.email ? existingUser.email.toLowerCase() : null;
+      if (normalizedNewEmail && normalizedNewEmail !== normalizedExistingEmail) {
         const emailExists = await User.findOne({
-          email: updateData.email.toLowerCase(),
+          email: normalizedNewEmail,
           _id: { $ne: id },
         });
         if (emailExists) {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -632,8 +632,10 @@ router.post(
       }
 
       const { emailOrMobile, password } = req.body;
+      // Normalize email to lowercase for consistent matching (emails are stored lowercase)
+      const normalizedEmailOrMobile = emailOrMobile.toLowerCase();
       // Try to find user by email first
-      let user = await User.findOne({ email: emailOrMobile, role: "USER" });
+      let user = await User.findOne({ email: normalizedEmailOrMobile, role: "USER" });
 
       // If not found by email, try by phone number
       if (!user) {
@@ -816,10 +818,12 @@ router.post(
         });
       }
 
+      // Normalize email to lowercase for consistent matching (emails are stored lowercase)
+      const normalizedIdentifier = identifier.toLowerCase();
       // Try to find admin user by email first
-      let user = await User.findOne({ email: identifier, role: "ADMIN" });
+      let user = await User.findOne({ email: normalizedIdentifier, role: "ADMIN" });
 
-      // If not found by email, try by phone number
+      // If not found by email, try by phone number (use original identifier, not normalized)
       if (!user) {
         user = await findUserByPhone(User, identifier);
         // Make sure it's an admin user


### PR DESCRIPTION
Prevents users from logging in with old emails after admin changes and ensures case-insensitive email matching in authentication.