### PR TITLE
feat(observability): wire up Sentry error tracking

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,6 +123,13 @@ pipeline {
 
                 cp ${ENV_FILE_PATH} ${WORKSPACE}/.env
                 echo "✅ .env file copied to workspace"
+
+                # Stamp this build as the Sentry release so every error
+                # maps to the exact deploy that introduced it
+                sed -i '/^SENTRY_RELEASE=/d' ${WORKSPACE}/.env
+                echo "SENTRY_RELEASE=build-${BUILD_NUMBER}" >> ${WORKSPACE}/.env
+                echo "✅ SENTRY_RELEASE=build-${BUILD_NUMBER} stamped into .env"
+
                 ls -la ${WORKSPACE}/.env
                 '''
             }

--- a/docs/SENTRY.md
+++ b/docs/SENTRY.md
@@ -1,0 +1,103 @@
+# Sentry Setup Runbook
+
+Error tracking for all Jackson apps (backend, admin, Android, iOS) via
+sentry.io. UAT and production share the same projects — events are separated
+by the `environment` tag each SDK sends.
+
+Everything ships **disabled by default**: until a DSN is configured, the SDKs
+no-op. Each step below can be done independently and verified before the next.
+
+Plan note: the free Developer plan includes 5k errors/month and 1 user seat.
+The SDK config is errors-only (no tracing/replay) to stay within that quota.
+
+---
+
+## 1. Sentry account + projects — DONE (2026-08-04)
+
+Org: **365-aitech** (https://365-aitech.sentry.io), 3 projects created.
+Ingestion verified end-to-end with a test event on jackson-backend.
+
+| Project | DSN |
+|---|---|
+| jackson-backend | `https://da5e6d17d810ceadde715adfc76a5a26@o4511852755550208.ingest.us.sentry.io/4511852772720640` |
+| jackson-admin | `https://02d771aaff8b64e50f1ba28d480385d2@o4511852755550208.ingest.us.sentry.io/4511852798148608` |
+| jackson-mobile | `https://5edf5b539511322705162cbb7cf7c286@o4511852755550208.ingest.us.sentry.io/4511852816629760` |
+
+(DSNs are write-only credentials — safe to commit and to embed in builds.)
+
+Alerts: each project has the default "notify on high-priority issues" email
+rule. Recommended extra rule per project: error-spike alert (e.g. "more than
+50 events in 1 hour").
+
+## 2. Backend UAT, then prod (~10 min each, needs: SSH)
+
+```bash
+nano /var/www/env-backups/.env.jackson-app-server
+```
+
+Add (UAT server → `uat`, prod server → `production`):
+
+```
+SENTRY_DSN=https://da5e6d17d810ceadde715adfc76a5a26@o4511852755550208.ingest.us.sentry.io/4511852772720640
+SENTRY_ENVIRONMENT=uat
+```
+
+Redeploy via Jenkins (the pipeline also stamps `SENTRY_RELEASE=build-<n>`
+automatically). Then verify:
+
+```bash
+curl https://rewardsuatapi.hireagent.co/debug-sentry
+# -> 500 response; the event must appear in Sentry within seconds,
+#    tagged environment=uat
+```
+
+(`/debug-sentry` only exists when NODE_ENV != production; on prod verify by
+watching for the first real error.)
+
+Repeat on prod with `SENTRY_ENVIRONMENT=production`.
+
+## 3. Admin panel (~5 min, needs: Vercel access)
+
+Vercel → rewards-admin project → Settings → Environment Variables:
+
+```
+NEXT_PUBLIC_SENTRY_DSN=https://02d771aaff8b64e50f1ba28d480385d2@o4511852755550208.ingest.us.sentry.io/4511852798148608
+NEXT_PUBLIC_SENTRY_ENV=production   # or uat for preview envs
+```
+
+Redeploy. Verify: log in to the admin, run
+`throw new Error("sentry test")` in the browser console — the event appears
+with the admin's user id/email attached.
+
+## 4. Mobile apps (needs: Codemagic access / Android build env)
+
+- **iOS**: codemagic.yaml already contains the `jackson-mobile` DSN and
+  `NEXT_PUBLIC_SENTRY_ENV: uat` — nothing to do for UAT builds; flip the
+  env to `production` for App Store builds.
+- **Android**: set in the `.env` used when running `build-aab.bat`:
+  `NEXT_PUBLIC_SENTRY_DSN=https://5edf5b539511322705162cbb7cf7c286@o4511852755550208.ingest.us.sentry.io/4511852816629760`
+- Verify: TestFlight/internal build → force an API failure or crash →
+  event appears tagged `platform: ios|android` with the user id.
+
+## 5. Uptime monitoring (~5 min, no access needed)
+
+UptimeRobot free tier → two HTTP monitors:
+
+- `https://rewardsuatapi.hireagent.co/health`
+- `https://rewardsapi.hireagent.co/health`
+
+Alert contact: same email as Sentry alerts.
+
+---
+
+## Notes
+
+- **Quota**: free tier caps at 5k errors/month — if a noisy issue burns
+  quota, use the issue's "Delete and discard future events" or add it to
+  the SDK `ignoreErrors` list.
+- **Seats**: 1 user on the free plan; teammates can't log in until upgraded.
+  Alert emails can still go to a shared address/group.
+- **Retention**: 30 days on the free plan.
+- **If volume outgrows the free tier**: self-hosted GlitchTip is
+  API-compatible — switching back is a DSN change only (the stack config
+  existed at git history of this branch if ever needed).

--- a/env.example
+++ b/env.example
@@ -9,6 +9,15 @@ JWT_EXPIRES_IN=7d
 PORT=4001
 NODE_ENV=development
 
+# Error Tracking (Sentry)
+# DSN from sentry.io: Settings > Projects > jackson-backend > Client Keys (DSN)
+# Leave empty to disable error tracking
+SENTRY_DSN=
+# uat | production (shown as "environment" on every event)
+SENTRY_ENVIRONMENT=uat
+# Optional: release identifier (e.g. git SHA or Jenkins build number)
+SENTRY_RELEASE=
+
 # Frontend URL (for OAuth redirects)
 FRONTEND_URL=http://localhost:3000
 

--- a/instrument.js
+++ b/instrument.js
@@ -1,63 +1,45 @@
 const Sentry = require("@sentry/node");
 const dotenv = require("dotenv");
 const { context, trace } = require("@opentelemetry/api");
-const { NodeSDK } = require("@opentelemetry/sdk-node");
-const {
-  getNodeAutoInstrumentations,
-} = require("@opentelemetry/auto-instrumentations-node");
-const {
-  OTLPTraceExporter,
-} = require("@opentelemetry/exporter-trace-otlp-http");
-const {
-  OTLPMetricExporter,
-} = require("@opentelemetry/exporter-metrics-otlp-http");
-const {
-  PeriodicExportingMetricReader,
-} = require("@opentelemetry/sdk-metrics");
-const { Resource } = require("@opentelemetry/resources");
-const {
-  SemanticResourceAttributes,
-} = require("@opentelemetry/semantic-conventions");
 
 dotenv.config();
 
-const otlpEndpoint =
-  process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://localhost:4318";
-const serviceName =
-  process.env.OTEL_SERVICE_NAME || "jackson-app-backend";
+// Error tracking via Sentry (sentry.io).
+// OpenTelemetry (traces/metrics) is configured separately in otel.js —
+// skipOpenTelemetrySetup prevents the two from registering competing providers.
+const dsn = process.env.SENTRY_DSN;
 
-const sdk = new NodeSDK({
-  resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
-  }),
-  traceExporter: new OTLPTraceExporter({
-    url: `${otlpEndpoint}/v1/traces`,
-  }),
-  metricReader: new PeriodicExportingMetricReader({
-    exporter: new OTLPMetricExporter({
-      url: `${otlpEndpoint}/v1/metrics`,
-    }),
-    exportIntervalMillis: 5000,
-  }),
-  instrumentations: [getNodeAutoInstrumentations()],
-});
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment:
+      process.env.SENTRY_ENVIRONMENT ||
+      process.env.NODE_ENV ||
+      "development",
+    release: process.env.SENTRY_RELEASE || undefined,
+    skipOpenTelemetrySetup: true,
+    sendDefaultPii: false,
+    beforeSend(event) {
+      // Correlate Sentry events with OTel traces (viewable in Tempo/Grafana)
+      const span = trace.getSpan(context.active());
+      if (span) {
+        const spanContext = span.spanContext();
+        event.tags = {
+          ...event.tags,
+          trace_id: spanContext.traceId,
+          span_id: spanContext.spanId,
+        };
+      }
+      return event;
+    },
+  });
+  console.log(
+    `✅ Sentry error tracking initialized (env: ${
+      process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "development"
+    })`,
+  );
+} else {
+  console.log("ℹ️ Sentry error tracking disabled (SENTRY_DSN not set)");
+}
 
-sdk.start();
-console.log("✅ OpenTelemetry initialized (traces + metrics)");
-
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  sendDefaultPii: true,
-  beforeSend(event) {
-    const span = trace.getSpan(context.active());
-    if (span) {
-      const spanContext = span.spanContext();
-      event.tags = {
-        ...event.tags,
-        trace_id: spanContext.traceId,
-        span_id: spanContext.spanId,
-      };
-    }
-    return event;
-  },
-});
+module.exports = Sentry;

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 require("./otel");
 require("dotenv").config();
-const Sentry = require("@sentry/node");
+const Sentry = require("./instrument");
 const express = require("express");
 const mongoose = require("mongoose");
 const cors = require("cors");
@@ -18,8 +18,6 @@ const {
   requestDurationHistogram,
 } = require("./metrics");
 const logger = require("./utils/logger");
-
-const AWS_KEY = "AKIA1234567890EXAMPLE";
 
 // Initialize Redis client
 let redis;
@@ -94,6 +92,7 @@ app.use((req, res, next) => {
       status: res.statusCode,
       duration_ms: durationMs,
       trace_id: traceId,
+      user_id: req.user?.userId || req.user?.id,
       ip: req.ip,
       user_agent: req.headers["user-agent"],
     });
@@ -381,6 +380,32 @@ mongoose
     app.use("/api/zoho", zohoRoutes);
     app.use("/api/non-gaming-survey", nonGamingSurveyRoutes);
 
+    // Test route to verify error-tracking wiring end to end (never in production)
+    if (process.env.NODE_ENV !== "production") {
+      app.get("/debug-sentry", function mainHandler(req, res) {
+        throw new Error("Sentry test error!");
+      });
+    }
+
+    // Report unhandled route errors to Sentry with user + request context,
+    // then fall through to the JSON error responder below.
+    app.use((err, req, res, next) => {
+      Sentry.withScope((scope) => {
+        const userId = req.user?.userId || req.user?.id;
+        if (userId) {
+          scope.setUser({ id: String(userId) });
+        }
+        scope.setContext("request", {
+          method: req.method,
+          path: req.originalUrl || req.url,
+          ip: req.ip,
+          user_agent: req.headers["user-agent"],
+        });
+        Sentry.captureException(err);
+      });
+      next(err);
+    });
+
     // Error handling middleware
     app.use((err, req, res, next) => {
       logger.error(err.stack);
@@ -400,19 +425,6 @@ mongoose
           ...(process.env.NODE_ENV === "development" && { stack: err.stack }),
         },
       });
-    });
-
-    app.get("/debug-sentry", function mainHandler(req, res) {
-      throw new Error("My first Sentry error!");
-    });
-
-    Sentry.setupExpressErrorHandler(app);
-    // Optional fallthrough error handler
-    app.use(function onError(err, req, res, next) {
-      // The error id is attached to `res.sentry` to be returned
-      // and optionally displayed to the user for support.
-      res.statusCode = 500;
-      res.end(res.sentry + "\n");
     });
 
     // Graceful shutdown handling


### PR DESCRIPTION
## Summary
- **Fix broken Sentry setup**: the SDK was installed but `Sentry.init` was never called (instrument.js was never loaded), and the error handler was registered after the JSON responder so no error could ever reach it. Both fixed.
- Every unhandled route error is now reported to Sentry (org: 365-aitech, project: jackson-backend) with the **user id**, request context, `environment` (uat/production) and `release` tags, plus OTel trace correlation.
- `user_id` added to the structured `http_request` winston logs for per-user activity trails.
- Jenkinsfile stamps `SENTRY_RELEASE=build-<n>` into the deploy env so errors map to deploys.
- `/debug-sentry` test route gated to non-production; removed unused hardcoded `AWS_KEY`.
- `docs/SENTRY.md`: full go-live runbook with the real DSNs.

## Activation
Disabled until `SENTRY_DSN` + `SENTRY_ENVIRONMENT` are added to the server env files (see docs/SENTRY.md). Ingestion already verified end-to-end with a test event.

## Testing
- `node --check` on edited files
- Test event sent through instrument.js to the real Sentry project: received with user/env/release tags ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)