### PR TITLE
Fix Walkathon transaction references

### DIFF
--- a/routes/admin-transactions.js
+++ b/routes/admin-transactions.js
@@ -14,6 +14,7 @@ const User = require("../models/User");
 const WalletAuditLog = require("../models/WalletAuditLog");
 const XPTier = require("../models/XPTier");
 const ConversionSettings = require("../models/ConversionSettings");
+const { getAdminTransactionId } = require("../utils/transactionReference");
 
 // ==================== SCREEN 1: TRANSACTION LOG ====================
 
@@ -125,7 +126,7 @@ router.get(
       // Format for frontend
       const formattedTransactions = transactions.map((tx) => ({
         ...tx,
-        transactionId: tx.referenceId,
+        transactionId: getAdminTransactionId(tx),
         userId: tx.user?._id || tx.user,
         userName: tx.user
           ? `${tx.user.firstName} ${tx.user.lastName}`

--- a/services/walkathonService.js
+++ b/services/walkathonService.js
@@ -10,7 +10,7 @@ const StepData = require('../models/StepData');
 const User = require('../models/User');
 const Transaction = require('../models/Transaction');
 const Leaderboard = require('../models/Leaderboard');
-const { 
+const {
   getISOWeekKey, 
   getWeekBounds, 
   getDefaultRewardTiers, 
@@ -20,6 +20,10 @@ const {
   generateWalkathonStats,
   getTimeRemaining
 } = require('../utils/walkathonHelpers');
+const {
+  buildWalkathonReferenceId,
+  getEntityId
+} = require('../utils/transactionReference');
 const { applyTierMultiplierToXP } = require('../utils/xpTierMultiplier');
 
 /**
@@ -312,6 +316,8 @@ async function claimReward(userId, milestone) {
     );
     user.xp.current = (user.xp.current || 0) + finalXP;
     user.xp.total = (user.xp.total || 0) + finalXP;
+
+    const walkathonId = getEntityId(activeWalkathon);
     
     // Create transaction record
     const transaction = new Transaction({
@@ -321,13 +327,13 @@ async function claimReward(userId, milestone) {
       description: `Walkathon Reward - ${milestone} steps milestone`,
       status: 'completed',
       metadata: {
-        walkathonId: progress.walkathonId,
+        walkathonId,
         weekKey: activeWalkathon.weekKey,
         milestone: milestone,
         xpEarned: reward.xpEarned,
         source: 'walkathon'
       },
-      referenceId: `WALKATHON-${progress.walkathonId}-${milestone}-${Date.now()}`
+      referenceId: buildWalkathonReferenceId(activeWalkathon, milestone)
     });
 
     await transaction.save();
@@ -342,7 +348,7 @@ async function claimReward(userId, milestone) {
     await user.save();
 
     // Update walkathon stats
-    await Walkathon.findByIdAndUpdate(progress.walkathonId, {
+    await Walkathon.findByIdAndUpdate(walkathonId, {
       $inc: { totalRewardsClaimed: 1 }
     });
 

--- a/test/transactionReference.test.js
+++ b/test/transactionReference.test.js
@@ -1,0 +1,45 @@
+const {
+  buildWalkathonReferenceId,
+  getAdminTransactionId,
+  getEntityId,
+} = require("../utils/transactionReference");
+
+describe("transaction reference helpers", () => {
+  const walkathonId = "6a83f1d314c1894d764db1af";
+
+  test("extracts an ID from a populated document", () => {
+    expect(getEntityId({ _id: walkathonId, weekKey: "2026-W34" })).toBe(
+      walkathonId
+    );
+  });
+
+  test("builds a compact Walkathon reference from a populated document", () => {
+    expect(
+      buildWalkathonReferenceId(
+        { _id: walkathonId, weekKey: "2026-W34" },
+        1000,
+        1787300000000
+      )
+    ).toBe(`WALKATHON-${walkathonId}-1000-1787300000000`);
+  });
+
+  test("uses the Mongo transaction ID for a legacy expanded reference", () => {
+    const transactionId = "6a86b08fa186fb1ad5be1234";
+    const expandedReference = `WALKATHON-${"raw challenge data ".repeat(20)}`;
+
+    expect(
+      getAdminTransactionId({
+        _id: transactionId,
+        referenceId: expandedReference,
+      })
+    ).toBe(transactionId);
+  });
+
+  test("keeps a valid compact reference", () => {
+    const referenceId = `WALKATHON-${walkathonId}-1000-1787300000000`;
+
+    expect(
+      getAdminTransactionId({ _id: "fallback", referenceId })
+    ).toBe(referenceId);
+  });
+});

--- a/utils/transactionReference.js
+++ b/utils/transactionReference.js
@@ -1,0 +1,43 @@
+const MAX_DISPLAY_REFERENCE_LENGTH = 160;
+
+function getEntityId(value) {
+  const candidate = value?._id ?? value;
+  return candidate == null ? "" : candidate.toString();
+}
+
+function buildWalkathonReferenceId(walkathon, milestone, timestamp = Date.now()) {
+  const walkathonId = getEntityId(walkathon);
+  if (!walkathonId) {
+    throw new Error("Walkathon ID is required to create a transaction reference");
+  }
+
+  return `WALKATHON-${walkathonId}-${milestone}-${timestamp}`;
+}
+
+function getAdminTransactionId(transaction) {
+  const referenceId = transaction?.referenceId;
+  const fallbackId = getEntityId(transaction);
+
+  if (typeof referenceId !== "string" || referenceId.length === 0) {
+    return fallbackId;
+  }
+
+  // Older Walkathon claims interpolated a populated Mongoose document into
+  // referenceId. Those values contain the entire challenge and can make the
+  // admin transaction table thousands of pixels wide. Preserve the record,
+  // but use its Mongo ID as the safe admin-facing identifier.
+  if (
+    referenceId.startsWith("WALKATHON-") &&
+    referenceId.length > MAX_DISPLAY_REFERENCE_LENGTH
+  ) {
+    return fallbackId;
+  }
+
+  return referenceId;
+}
+
+module.exports = {
+  buildWalkathonReferenceId,
+  getAdminTransactionId,
+  getEntityId,
+};


### PR DESCRIPTION
Fixes BUG 021. New claims use a compact Walkathon ObjectId reference, and legacy oversized references fall back to the transaction Mongo ID in the admin list. Includes focused helper tests and syntax/assertion verification.