### PR TITLE
feat(vip): support tier/plan change for active subscribers (BUG_005)

### DIFF
--- a/models/VIPSubscription.js
+++ b/models/VIPSubscription.js
@@ -81,7 +81,12 @@ const vipSubscriptionSchema = new mongoose.Schema({
     originalTransactionId: String,
     productId: String,
     appStoreEnvironment: String,
-    sessionId: String
+    sessionId: String,
+    // Set on the OLD subscription when a verified purchase replaces it
+    // (tier/plan change, e.g. Gold -> Platinum)
+    replacedByTransactionId: String,
+    replacedAt: Date,
+    replacementReason: String
   },
   createdAt: { 
     type: Date, 

--- a/routes/vip-membership.js
+++ b/routes/vip-membership.js
@@ -367,12 +367,15 @@ router.post('/initiate-purchase', auth, [
     const { tierId, plan, region = 'US' } = req.body;
     const userId = req.user.userId;
 
-    // Check if user already has active subscription
+    // An active subscriber may change tier/plan (e.g. Gold -> Platinum).
+    // Only an identical repurchase is rejected; the previous subscription is
+    // closed in complete-purchase once Apple verifies the new transaction.
     const activeSubscription = await VIPSubscription.getActiveSubscription(userId);
-    if (activeSubscription && activeSubscription.isActive()) {
+    const isTierChange = !!(activeSubscription && activeSubscription.isActive());
+    if (isTierChange && activeSubscription.tier === tierId && activeSubscription.plan === plan) {
       return res.status(400).json({
         success: false,
-        error: 'User already has an active subscription'
+        error: 'You are already subscribed to this tier and plan'
       });
     }
 
@@ -414,6 +417,9 @@ router.post('/initiate-purchase', auth, [
         expiresAt: purchaseSession.expiresAt,
         appStoreProductId: `${tierId}_${plan}`, // iOS App Store product ID
         pricing: tierPricing[plan], // Full pricing details for frontend
+        tierChange: isTierChange
+          ? { fromTier: activeSubscription.tier, fromPlan: activeSubscription.plan }
+          : null,
         instructions: {
           title: 'Complete Purchase',
           description: 'Use the session ID to complete your purchase in the App Store',
@@ -517,13 +523,21 @@ router.post('/complete-purchase', auth, [
       });
     }
 
-    // Check if user already has active subscription
+    // A verified purchase from a user with an active subscription is a
+    // tier/plan change: close the previous subscription and activate the new
+    // one. Identical repurchases were already rejected at initiate-purchase,
+    // and true duplicates are caught by the transaction idempotency check
+    // above, so reaching here with the same tier+plan means a genuine new
+    // Apple transaction that must not be discarded.
     const existingSubscription = await VIPSubscription.getActiveSubscription(userId);
     if (existingSubscription && existingSubscription.isActive()) {
-      return res.status(400).json({
-        success: false,
-        error: 'User already has an active subscription'
-      });
+      existingSubscription.status = 'cancelled';
+      existingSubscription.autoRenew = false;
+      existingSubscription.endDate = new Date();
+      existingSubscription.metadata.replacedByTransactionId = receiptVerification.transactionId;
+      existingSubscription.metadata.replacedAt = new Date();
+      existingSubscription.metadata.replacementReason = 'tier_change';
+      await existingSubscription.save();
     }
 
     // Get pricing for the tier and plan


### PR DESCRIPTION
Implements the missing VIP upgrade path (second half of BUG_005): an existing subscriber (e.g. Gold) upgrading to another tier (e.g. Platinum) was hard-rejected at session creation, which the app surfaced as "The purchase session could not be created."

Changes:
- `initiate-purchase`: active subscribers may now create a session for a *different* tier/plan; only an identical tier+plan repurchase is rejected. The response includes `tierChange: { fromTier, fromPlan }` so the client can show upgrade context (additive field — current client ignores it safely).
- `complete-purchase`: once Apple verifies the new transaction, the previous active subscription is closed (`cancelled`, `autoRenew: false`, `endDate: now`, plus `replacedByTransactionId` / `replacedAt` / `replacementReason` metadata) and the new one is activated. Existing transaction-idempotency and cross-account checks are untouched — a verified charge is never discarded.
- `VIPSubscription` model: added the three replacement-tracking metadata fields (the metadata subdocument is strict, so unknown keys would have been dropped).

External check for the team: confirm in App Store Connect that the tier products (`gold_monthly`, `platinum_monthly`, …) are auto-renewable subscriptions in the **same subscription group** — that's what makes StoreKit treat this as a prorated upgrade rather than a second parallel subscription. The backend behaves correctly either way (it records whatever Apple verifies), but billing UX depends on the group config.

Verification: `node --check` passes on both files. Device test: Gold sandbox account → upgrade to Platinum → expect old subscription cancelled with replacement metadata, new one active, `User.vip.level` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)