### PR TITLE
feat(iap): accept StoreKit 2 signed transactions (JWS) as proof of purchase

### DIFF
--- a/models/VIPSubscription.js
+++ b/models/VIPSubscription.js
@@ -81,6 +81,7 @@ const vipSubscriptionSchema = new mongoose.Schema({
     originalTransactionId: String,
     productId: String,
     appStoreEnvironment: String,
+    verificationMethod: String, // 'receipt' | 'jws'
     sessionId: String,
     // Set on the OLD subscription when a verified purchase replaces it
     // (tier/plan change, e.g. Gold -> Platinum)

--- a/routes/vip-membership.js
+++ b/routes/vip-membership.js
@@ -7,7 +7,8 @@ const VIPTier = require('../models/VIPTier');
 const VIPSubscription = require('../models/VIPSubscription');
 const { getVIPPricing } = require('../utils/pricing');
 const { getUserVIPBenefits } = require('../utils/vipBenefits');
-const { verifyAppStoreReceipt } = require('../utils/appStoreVerification');
+const { verifyAppStoreReceipt, verifyAppStoreJws } = require('../utils/appStoreVerification');
+const config = require('../config/config');
 
 // ==================== VIP MEMBERSHIP SCREEN ====================
 
@@ -448,7 +449,11 @@ router.post('/initiate-purchase', auth, [
  */
 router.post('/complete-purchase', auth, [
   body('sessionId').notEmpty().withMessage('Session ID is required'),
-  body('appStoreReceipt').notEmpty().withMessage('App Store receipt is required'),
+  // StoreKit 2 purchases (TestFlight/sandbox especially) may not produce the
+  // legacy base64 receipt; they always carry a signed transaction (JWS).
+  // Either proof of purchase is accepted.
+  body('appStoreReceipt').optional({ checkFalsy: true }).isString(),
+  body('jwsRepresentation').optional({ checkFalsy: true }).isString(),
   body('transactionId').notEmpty().withMessage('Transaction ID is required'),
   body('productId').notEmpty().withMessage('Product ID is required')
 ], async (req, res) => {
@@ -462,8 +467,15 @@ router.post('/complete-purchase', auth, [
       });
     }
 
-    const { sessionId, appStoreReceipt, transactionId, productId } = req.body;
+    const { sessionId, appStoreReceipt, jwsRepresentation, transactionId, productId } = req.body;
     const userId = req.user.userId;
+
+    if (!appStoreReceipt && !jwsRepresentation) {
+      return res.status(400).json({
+        success: false,
+        error: 'Either an App Store receipt or a signed transaction (jwsRepresentation) is required'
+      });
+    }
 
     // Verify the session exists and is valid
     // In production, you would validate this against your session store
@@ -483,8 +495,15 @@ router.post('/complete-purchase', auth, [
       });
     }
 
-    // Verify App Store receipt (in production, use Apple's verification service)
-    const receiptVerification = await verifyAppStoreReceipt(appStoreReceipt, productId);
+    // Verify proof of purchase: legacy receipt via Apple's verifyReceipt API,
+    // or a StoreKit 2 signed transaction verified offline against Apple's CA.
+    const receiptVerification = appStoreReceipt
+      ? await verifyAppStoreReceipt(appStoreReceipt, productId)
+      : verifyAppStoreJws(jwsRepresentation, {
+          bundleId: config.APP_BUNDLE_ID,
+          productId,
+          transactionId
+        });
     if (!receiptVerification.valid) {
       return res.status(400).json({
         success: false,
@@ -580,6 +599,7 @@ router.post('/complete-purchase', auth, [
         originalTransactionId: receiptVerification.originalTransactionId,
         productId,
         appStoreEnvironment: receiptVerification.environment,
+        verificationMethod: receiptVerification.method || 'receipt',
         sessionId
       }
     });

--- a/utils/appStoreVerification.js
+++ b/utils/appStoreVerification.js
@@ -233,8 +233,103 @@ const getSubscriptionStatus = async (receiptData) => {
   }
 };
 
+// SHA-256 fingerprint of Apple Root CA - G3 (https://www.apple.com/certificateauthority/),
+// the root of the certificate chain embedded in every StoreKit 2 signed transaction.
+const APPLE_ROOT_CA_G3_FINGERPRINT256 =
+  '63:34:3A:BF:B8:9A:6A:03:EB:B5:7E:9B:3F:5F:A7:BE:7C:4F:5C:75:6F:30:17:B3:A8:C4:88:C3:65:3E:91:79';
+
+const base64UrlToBuffer = (value) =>
+  Buffer.from(value.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+
+/**
+ * Verify a StoreKit 2 signed transaction (JWS) entirely offline.
+ *
+ * StoreKit 2 purchases do not always produce the legacy app-store receipt file
+ * (notably in TestFlight/sandbox), but they always carry a jwsRepresentation
+ * signed by Apple. The JWS embeds its x5c certificate chain; verification
+ * checks the chain links, pins the root to Apple Root CA - G3, verifies the
+ * ES256 signature with the leaf certificate, then validates the payload claims
+ * against what the client reported.
+ *
+ * @param {string} jws - The signed transaction (header.payload.signature)
+ * @param {Object} expected - { bundleId, productId, transactionId }
+ * @returns {Object} Same shape as verifyAppStoreReceipt results
+ */
+const verifyAppStoreJws = (jws, expected = {}) => {
+  const crypto = require('crypto');
+  try {
+    if (typeof jws !== 'string' || jws.split('.').length !== 3) {
+      return { valid: false, error: 'Malformed signed transaction (JWS)' };
+    }
+    const [headerB64, payloadB64, signatureB64] = jws.split('.');
+    const header = JSON.parse(base64UrlToBuffer(headerB64).toString('utf8'));
+    if (header.alg !== 'ES256' || !Array.isArray(header.x5c) || header.x5c.length < 2) {
+      return { valid: false, error: 'Unsupported signed transaction header' };
+    }
+
+    const chain = header.x5c.map(
+      (cert) => new crypto.X509Certificate(Buffer.from(cert, 'base64'))
+    );
+    for (let i = 0; i < chain.length - 1; i++) {
+      if (!chain[i].verify(chain[i + 1].publicKey)) {
+        return { valid: false, error: 'Signed transaction certificate chain is invalid' };
+      }
+    }
+    const rootCert = chain[chain.length - 1];
+    if (rootCert.fingerprint256 !== APPLE_ROOT_CA_G3_FINGERPRINT256) {
+      return { valid: false, error: 'Signed transaction is not rooted in Apple Root CA - G3' };
+    }
+
+    const signatureValid = crypto.verify(
+      'sha256',
+      Buffer.from(`${headerB64}.${payloadB64}`),
+      { key: chain[0].publicKey, dsaEncoding: 'ieee-p1363' },
+      base64UrlToBuffer(signatureB64)
+    );
+    if (!signatureValid) {
+      return { valid: false, error: 'Signed transaction signature verification failed' };
+    }
+
+    const payload = JSON.parse(base64UrlToBuffer(payloadB64).toString('utf8'));
+
+    if (expected.bundleId && payload.bundleId !== expected.bundleId) {
+      return {
+        valid: false,
+        error: `Signed transaction bundle ID ${payload.bundleId || '(missing)'} does not match this application`
+      };
+    }
+    if (expected.productId && payload.productId !== expected.productId) {
+      return { valid: false, error: 'Signed transaction product does not match the purchase' };
+    }
+    if (expected.transactionId && String(payload.transactionId) !== String(expected.transactionId)) {
+      return { valid: false, error: 'Signed transaction ID does not match the purchase' };
+    }
+    if (payload.revocationDate) {
+      return { valid: false, error: 'This App Store transaction has been revoked' };
+    }
+
+    return {
+      valid: true,
+      method: 'jws',
+      transactionId: String(payload.transactionId),
+      productId: payload.productId,
+      purchaseDate: payload.purchaseDate
+        ? new Date(payload.purchaseDate).toISOString()
+        : null,
+      expiresDate: payload.expiresDate
+        ? new Date(payload.expiresDate).toISOString()
+        : null,
+      originalTransactionId: String(payload.originalTransactionId || payload.transactionId),
+      environment: payload.environment
+    };
+  } catch (error) {
+    return { valid: false, error: 'Signed transaction verification error: ' + error.message };
+  }
+};
+
 module.exports = {
   verifyAppStoreReceipt,
+  verifyAppStoreJws,
   validateSubscriptionPurchase,
   getSubscriptionStatus,
   getAppStoreErrorDescription


### PR DESCRIPTION
Second half of the BUG_005 free-user fix (pairs with jacksonios PR for `codex/iap-jws-client`).

Tester evidence on build 122 showed Apple confirming the purchase while the app reported no verification receipt: StoreKit 2 purchases (TestFlight/sandbox especially) often produce **no legacy app-store receipt file**, so the client has nothing to send to `verifyReceipt`. The plugin does always provide the StoreKit 2 **signed transaction (JWS)**.

`complete-purchase` now accepts either proof:
- `appStoreReceipt` → existing Apple `verifyReceipt` flow, unchanged
- `jwsRepresentation` → verified **fully offline**: x5c certificate chain links validated, root pinned to Apple Root CA – G3 by SHA-256 fingerprint (fetched from apple.com/certificateauthority), ES256 signature verified with the leaf certificate, then `bundleId`/`productId`/`transactionId` claims matched against the request; revoked transactions rejected. Verification method recorded in subscription metadata.

Tested: negative paths (malformed JWS, wrong alg, broken chain) all reject gracefully; a correctly-signed JWS chained to a non-Apple root is rejected at the CA pin. The positive path requires a genuine Apple-signed transaction — covered by the sandbox device test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)