### PR TITLE
fix(discover): exclude blank uiSection names from discover response

### DIFF
--- a/routes/game.js
+++ b/routes/game.js
@@ -2042,7 +2042,12 @@ router.get("/discover", protect, async (req, res) => {
       console.log(`[DISCOVER RESPONSE] gameId=${g.gameId} rewards.coins=${g.rewards?.coins} goalsCount=${g.goals?.length} goalsTotalCoins=${g.goals?.reduce((s, gl) => s + (gl.coinReward || 0), 0)}`);
     });
 
-    const uiSections = await Game.distinct("uiSection");
+    // Exclude blank/missing section names: a game saved with an empty
+    // uiSection put "" into this list, which drove the iOS game-list screen
+    // into an infinite fetch loop (BUG_017 freeze).
+    const uiSections = (await Game.distinct("uiSection")).filter(
+      (s) => typeof s === "string" && s.trim() !== ""
+    );
 
     // Set cache-control headers to prevent 304 Not Modified responses
     res.set({


### PR DESCRIPTION
Backend half of the BUG_017 fix (pairs with jacksonios PR #9).

`/api/game/discover` returns `uiSections: ["", "Cash Coach Recommendation", ...]` on UAT — a game document exists with an empty `uiSection`, and `Game.distinct("uiSection")` faithfully includes `""`. The iOS game-list screen iterated that list and fell into an infinite fetch loop for the blank section (2,500+ requests per minute; iOS kills the pegged WKWebView, which is the tester-reported freeze + bounce to Home).

This filters blank/non-string values out of the response. The client also filters defensively on its side.

Data follow-up for the team: find the game(s) with empty `uiSection` in the UAT database and give them a real section (or fix the admin form to require one). Also noticed both "Game Tips" and "Gametips" exist as section names — likely a typo worth consolidating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)